### PR TITLE
Show symbol index that caused an error

### DIFF
--- a/dotenv/src/errors.rs
+++ b/dotenv/src/errors.rs
@@ -6,7 +6,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum Error {
-    LineParse(String),
+    LineParse(String, usize),
     Io(io::Error),
     EnvVar(std::env::VarError),
     #[doc(hidden)]
@@ -37,7 +37,7 @@ impl fmt::Display for Error {
         match self {
             Error::Io(err) => write!(fmt, "{}", err),
             Error::EnvVar(err) => write!(fmt, "{}", err),
-            Error::LineParse(line) => write!(fmt, "Error parsing line: '{}'", line),
+            Error::LineParse(line, error_index) => write!(fmt, "Error parsing line: '{}', error at line index: {}", line, error_index),
             _ => unreachable!(),
         }
     }
@@ -46,7 +46,7 @@ impl fmt::Display for Error {
 #[cfg(test)]
 mod test {
     use std::error::Error as StdError;
-    
+
     use super::*;
 
     #[test]
@@ -65,7 +65,7 @@ mod test {
 
     #[test]
     fn test_lineparse_error_source() {
-        let err = Error::LineParse("test line".to_string());
+        let err = Error::LineParse("test line".to_string(), 2);
         assert!(err.source().is_none());
     }
 
@@ -103,8 +103,8 @@ mod test {
 
     #[test]
     fn test_lineparse_error_display() {
-        let err = Error::LineParse("test line".to_string());
+        let err = Error::LineParse("test line".to_string(), 2);
         let err_desc = format!("{}", err);
-        assert_eq!("Error parsing line: 'test line'", err_desc);
+        assert_eq!("Error parsing line: 'test line', error at line index: 2", err_desc);
     }
 }

--- a/dotenv/src/parse.rs
+++ b/dotenv/src/parse.rs
@@ -173,7 +173,8 @@ fn parse_value(input: &str, substitution_data: &mut HashMap<String, Option<Strin
 
     //XXX also fail if escaped? or...
     if substitution_mode == SubstitutionMode::EscapedBlock || strong_quote || weak_quote {
-        Err(Error::LineParse(input.to_owned(), (input.len() - 1).max(0)))
+        let value_length = input.len();
+        Err(Error::LineParse(input.to_owned(), if value_length == 0 { 0 } else { value_length - 1 }))
     } else {
         apply_substitution(substitution_data, &substitution_name.drain(..).collect::<String>(), &mut output);
         Ok(output)

--- a/dotenv/src/parse.rs
+++ b/dotenv/src/parse.rs
@@ -173,7 +173,7 @@ fn parse_value(input: &str, substitution_data: &mut HashMap<String, Option<Strin
 
     //XXX also fail if escaped? or...
     if substitution_mode == SubstitutionMode::EscapedBlock || strong_quote || weak_quote {
-        Err(Error::LineParse(input.to_owned(), input.len() - 1))
+        Err(Error::LineParse(input.to_owned(), (input.len() - 1).max(0)))
     } else {
         apply_substitution(substitution_data, &substitution_name.drain(..).collect::<String>(), &mut output);
         Ok(output)

--- a/dotenv/src/parse.rs
+++ b/dotenv/src/parse.rs
@@ -29,7 +29,7 @@ pub fn parse_line(line: &str, mut substitution_data: &mut HashMap<String, Option
 
     LINE_REGEX
         .captures(line)
-        .map_or(Err(Error::LineParse(line.into())), |captures| {
+        .map_or(Err(Error::LineParse(line.into(), 0)), |captures| {
             let key = named_string(&captures, "key");
             let value = named_string(&captures, "value");
 
@@ -79,7 +79,7 @@ fn parse_value(input: &str, substitution_data: &mut HashMap<String, Option<Strin
     let mut substitution_mode = SubstitutionMode::None;
     let mut substitution_name = String::new();
 
-    for c in input.chars() {
+    for (index, c) in input.chars().enumerate() {
         //the regex _should_ already trim whitespace off the end
         //expecting_end is meant to permit: k=v #comment
         //without affecting: k=v#comment
@@ -90,7 +90,7 @@ fn parse_value(input: &str, substitution_data: &mut HashMap<String, Option<Strin
             } else if c == '#' {
                 break;
             } else {
-                return Err(Error::LineParse(input.to_owned()));
+                return Err(Error::LineParse(input.to_owned(), index));
             }
         } else if escaped {
             //TODO I tried handling literal \n \r but various issues
@@ -100,7 +100,7 @@ fn parse_value(input: &str, substitution_data: &mut HashMap<String, Option<Strin
             match c {
                 '\\' | '\'' | '"' | '$' | ' ' => output.push(c),
                 _ => {
-                    return Err(Error::LineParse(input.to_owned()));
+                    return Err(Error::LineParse(input.to_owned(), index));
                 }
             }
 
@@ -173,7 +173,7 @@ fn parse_value(input: &str, substitution_data: &mut HashMap<String, Option<Strin
 
     //XXX also fail if escaped? or...
     if substitution_mode == SubstitutionMode::EscapedBlock || strong_quote || weak_quote {
-        Err(Error::LineParse(input.to_owned()))
+        Err(Error::LineParse(input.to_owned(), input.len() - 1))
     } else {
         apply_substitution(substitution_data, &substitution_name.drain(..).collect::<String>(), &mut output);
         Ok(output)
@@ -303,7 +303,6 @@ KEY4=h\8u
 
 #[cfg(test)]
 mod variable_substitution_tests {
-    use crate::errors::Error::LineParse;
     use crate::iter::Iter;
 
     fn assert_parsed_string(input_string: &str, expected_parse_result: Vec<(&str, &str)>) {
@@ -478,13 +477,21 @@ mod variable_substitution_tests {
             ],
         );
     }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use crate::errors::Error::LineParse;
+    use crate::iter::Iter;
 
     #[test]
     fn should_not_parse_unfinished_substitutions() {
-        let parsed_values: Vec<_> = Iter::new(r#"
+        let wrong_value = ">${KEY{<";
+
+        let parsed_values: Vec<_> = Iter::new(format!(r#"
     KEY=VALUE
-    KEY1=>${KEY{<
-    "#.as_bytes()).collect();
+    KEY1={}
+    "#, wrong_value).as_bytes()).collect();
 
         assert_eq!(parsed_values.len(), 2);
 
@@ -494,8 +501,39 @@ mod variable_substitution_tests {
             assert!(false, "Expected the first value to be parsed")
         }
 
-        if let Err(LineParse(second_value)) = &parsed_values[1] {
-            assert_eq!(second_value, &String::from(">${KEY{<"))
+        if let Err(LineParse(second_value, index)) = &parsed_values[1] {
+            assert_eq!(second_value, wrong_value);
+            assert_eq!(*index, wrong_value.len() - 1)
+        } else {
+            assert!(false, "Expected the second value not to be parsed")
+        }
+    }
+
+    #[test]
+    fn should_not_parse_illegal_format() {
+        let wrong_format = r"<><><>";
+        let parsed_values: Vec<_> = Iter::new(wrong_format.as_bytes()).collect();
+
+        assert_eq!(parsed_values.len(), 1);
+
+        if let Err(LineParse(wrong_value, index)) = &parsed_values[0] {
+            assert_eq!(wrong_value, wrong_format);
+            assert_eq!(*index, 0)
+        } else {
+            assert!(false, "Expected the second value not to be parsed")
+        }
+    }
+
+    #[test]
+    fn should_not_parse_illegal_escape() {
+        let wrong_escape = r">\f<";
+        let parsed_values: Vec<_> = Iter::new(format!("VALUE={}", wrong_escape).as_bytes()).collect();
+
+        assert_eq!(parsed_values.len(), 1);
+
+        if let Err(LineParse(wrong_value, index)) = &parsed_values[0] {
+            assert_eq!(wrong_value, wrong_escape);
+            assert_eq!(*index, wrong_escape.find("\\").unwrap() + 1)
         } else {
             assert!(false, "Expected the second value not to be parsed")
         }

--- a/dotenv_codegen_implementation/src/lib.rs
+++ b/dotenv_codegen_implementation/src/lib.rs
@@ -1,22 +1,18 @@
 extern crate proc_macro;
 
+use proc_macro::TokenStream;
 use std::env;
 
-use syn::punctuated::Punctuated;
-use syn::parse::Parser;
-use syn::Token;
-use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
 use quote::quote;
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
+use syn::Token;
 
 #[proc_macro_hack]
 pub fn dotenv(input: TokenStream) -> TokenStream {
     if let Err(err) = dotenv::dotenv() {
-        if let dotenv::Error::LineParse(ref line) = err {
-            panic!("Error parsing .env file: {}", line);
-        } else {
-            panic!("Error loading .env file: {}", err);
-        }
+        panic!("Error loading .env file: {}", err);
     }
 
     // Either everything was fine, or we didn't find an .env file (which we ignore)

--- a/dotenv_codegen_implementation/src/lib.rs
+++ b/dotenv_codegen_implementation/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate proc_macro;
 
-use proc_macro::TokenStream;
 use std::env;
 
+use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::parse::Parser;


### PR DESCRIPTION
When the line parsed with an error is long, say `DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/$\{POSTGRES_DB}"`

it's rather hard to understand which symbol had caused a parsing error.

This PR makes it a bit more clearer.
It would be even more descriptive to actually highlight the wrong symbol instead with some symbol, say `^`, but not sure if it's a good approach for the library crate.