### PR TITLE
Replace line-parsing RegEx by manual code

### DIFF
--- a/dotenv/Cargo.toml
+++ b/dotenv/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "dotenv"
 version = "0.15.0"
-authors = ["Noemi Lapresta <noemi.lapresta@gmail.com>", "Craig Hills <chills@gmail.com>", "Mike Piccolo <mfpiccolo@gmail.com>", "Alice Maz <alice@alicemaz.com>", "Sean Griffin <sean@seantheprogrammer.com>", "Adam Sharp <adam@sharplet.me>"]
+authors = [
+  "Noemi Lapresta <noemi.lapresta@gmail.com>",
+  "Craig Hills <chills@gmail.com>",
+  "Mike Piccolo <mfpiccolo@gmail.com>",
+  "Alice Maz <alice@alicemaz.com>",
+  "Sean Griffin <sean@seantheprogrammer.com>",
+  "Adam Sharp <adam@sharplet.me>",
+  "Arpad Borsos <arpad.borsos@googlemail.com>",
+]
 description = "A `dotenv` implementation for Rust"
 homepage = "https://github.com/dotenv-rs/dotenv"
 readme = "../README.md"
@@ -15,8 +23,6 @@ name = "dotenv"
 required-features = ["cli"]
 
 [dependencies]
-lazy_static = "1.0.0"
-regex = "1.0"
 clap = { version = "2", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Replace line-parsing RegEx by manual code

This avoids pulling in `regex` and `lazy_static` and makes this a true
zero-dependency crate.