### PR TITLE
Native proc_macro 

### DIFF
--- a/dotenv_codegen/src/lib.rs
+++ b/dotenv_codegen/src/lib.rs
@@ -1,4 +1,4 @@
-use proc_macro_hack::proc_macro_hack;
+//use proc_macro_hack::proc_macro_hack;
 
-#[proc_macro_hack]
+#[proc_macro]
 pub use dotenv_codegen_implementation::dotenv;

--- a/dotenv_codegen_implementation/src/lib.rs
+++ b/dotenv_codegen_implementation/src/lib.rs
@@ -3,13 +3,13 @@ extern crate proc_macro;
 use std::env::{self, VarError};
 
 use proc_macro::TokenStream;
-use proc_macro_hack::proc_macro_hack;
+//use proc_macro_hack::proc_macro_hack;
 use quote::quote;
 use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::Token;
 
-#[proc_macro_hack]
+#[proc_macro]
 pub fn dotenv(input: TokenStream) -> TokenStream {
     if let Err(err) = dotenv::dotenv() {
         panic!("Error loading .env file: {}", err);


### PR DESCRIPTION
With Rust 1.45  `#[proc_macro_hack]` is no longer required as  `#[proc_macro]` has a native implementation (it also results in an annoying `unresolved-macro-call` error.

Consider [futures-macro](https://github.com/rust-lang/futures-rs/pull/2407/commits/c780528417e15a058cddf1b0ab69cc1b243c1383)'s implementation for supporting older Rust compilers.