### PR TITLE
Add default substitution

### DIFF
--- a/dotenv/src/parse.rs
+++ b/dotenv/src/parse.rs
@@ -305,7 +305,7 @@ fn get_substitution(
     std::env::var(substitution_name).ok().or_else(|| {
         substitution_data
             .get(substitution_name)
-            .and_then(|x| x.clone())
+            .and_then(|x| x.to_owned())
     })
 }
 


### PR DESCRIPTION
similar to bash allow following expansions from bash man page:
    
       ${parameter:-word}
              Use Default Values.  If parameter is unset or null, the
              expansion of word is substituted.  Otherwise, the value of
              parameter is substituted.
       ${parameter:=word}
              Assign Default Values.  If parameter is unset or null, the
              expansion of word is assigned to parameter.  The value of
              parameter is then substituted.  Positional parameters and
              special parameters may not be assigned to in this way.