### PR TITLE
add dotenv_values method

### DIFF
--- a/dotenv/src/lib.rs
+++ b/dotenv/src/lib.rs
@@ -179,3 +179,24 @@ pub fn dotenv_iter() -> Result<iter::Iter<File>> {
     let (_, iter) = Finder::new().find()?;
     Ok(iter)
 }
+
+
+/// Like `dotenv`, but returns an HashMap over variables instead of loading into environment.
+/// Unlike 'dotenv().ok()', this function only retrieves variables from the .env file, without loading them into the environment.
+/// # Examples
+/// ```no_run
+/// use dotenv;
+///
+/// let dotenv_values: std::collections::HashMap<String, String> = dotenv::dotenv_values().unwrap();
+/// dotenv_values.iter()
+///     .for_each(|item| println!("{:?}", item));
+///
+/// ```
+pub fn dotenv_values() -> Result<std::collections::HashMap<String, String>> {
+    let vars = dotenv_iter()?
+        .filter_map(|item| item.ok())
+        .collect::<std::collections::HashMap<String, String>>();
+
+    Ok(vars)
+}
+


### PR DESCRIPTION
This function is similar to the existing dotenv function, but instead of setting environment variables, it returns the contents of the .env file as a HashMap. This allows users to handle the contents of the .env file more flexibly.