### PR TITLE
Fix features definition

### DIFF
--- a/dotenv/Cargo.toml
+++ b/dotenv/Cargo.toml
@@ -29,4 +29,4 @@ clap = { version = "2", optional = true }
 tempfile = "3.0.0"
 
 [features]
-cli = ["clap"]
+cli = ["dep:clap"]


### PR DESCRIPTION
The current `cli` feature is using an implicit `clap` feature, and with 2 features is confusing to know the meaning of that intermediate feature. The fix is in the [docs](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies).

> If you specify the optional dependency with the dep: prefix anywhere in the [features] table, that disables the implicit feature.